### PR TITLE
Fixing documentation error

### DIFF
--- a/javav2/README.rst
+++ b/javav2/README.rst
@@ -33,7 +33,7 @@ To build and run these examples, you need the following:
              .build();
 
 
-**Note**: For more information about setting your AWS credentials, see  `Supplying and retrieving AWS credentials <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html/>`_.
+**Note**: For more information about setting your AWS credentials, see  `Supplying and retrieving AWS credentials <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html>`_.
 
 AWS Java code examples
 ======================


### PR DESCRIPTION
Removing extra slash which breaks the link. I hate AWS doc with a broken link ;-)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
